### PR TITLE
Fix cutting of character from rfc 2231 parameter value

### DIFF
--- a/class/mime/Rfc822Header.class.php
+++ b/class/mime/Rfc822Header.class.php
@@ -747,7 +747,7 @@ class Rfc822Header {
             $charset = substr($value,0,strpos($value,"'"));
             $value = substr($value,strlen($charset)+1);
             $language = substr($value,0,strpos($value,"'"));
-            $value = substr($value,strlen($charset)+1);
+            $value = substr($value,strlen($language)+1);
             /* FIXME: What's the status of charset decode with language information ????
              * Maybe language information contains only ascii text and charset_decode() 
              * only runs sm_encode_html_special_chars() on it. If it contains 8bit information, you 


### PR DESCRIPTION
It was discovered that this function cut of some character from RFC 2231 encode attachment filename in case that the charset and language are not the same length.

We use parts of this function in some other code and replaced the whole `substr` with:
```
        foreach ($aCharset as $key) {
            $value = explode("'", $aResults[$key], 3);
            // extract the charset & language
            $aResults['charset'] = $value[0];
            $aResults['language'] = $value[1];
            $aResults[$key] = charset_decode($aResults['charset'],$value[2]);
        }
```
Not sure if that would break something else in squirrelmail that's why i only suggest the minimal fix.